### PR TITLE
Prevent context menu in Mac Ctrl+click

### DIFF
--- a/src/components/Perspective.js
+++ b/src/components/Perspective.js
@@ -20,6 +20,7 @@ export default function Perspective({
       tabIndex={ 1 }
       onMouseUp={ onStretchStop }
       onMouseDown={ onStartDragView }
+      onContextMenu={ (e) => e.preventDefault() }
       style={{
         WebkitTransform: `rotateX(${rotation.x}deg) rotateZ(${rotation.z}deg)`
       }}


### PR DESCRIPTION
In mac ctrl+click causes the context menu to open, also the next actions with click becomes "removing", perspective div carrier should prevent opening context menu.